### PR TITLE
Replaced intval() by round() to fix intval() rounding problem

### DIFF
--- a/Config/module.xml
+++ b/Config/module.xml
@@ -15,7 +15,7 @@
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <authors>
         <author>
             <name>Franck Allimant</name>

--- a/Mercanet.php
+++ b/Mercanet.php
@@ -139,7 +139,7 @@ class Mercanet extends AbstractPaymentModule
         $paymentRequest->setKeyVersion(Mercanet::getConfigValue('secretKeyVersion'));
 
         $paymentRequest->setTransactionReference($transactionId);
-        $paymentRequest->setAmount(intval(100 * $amount));
+        $paymentRequest->setAmount(intval(round(100 * $amount)));
 
         $paymentRequest->setCurrency($order->getCurrency()->getCode());
 


### PR DESCRIPTION
Using intval(round(x)) instead of intval(x) on a floating point value leads to precision loss :

number_format(8.20*100, 20) = 819.99999999999988631316
intval(8.20*100) = 819
floor(8.20*100) = 819
round(8.20*100) = 820 (still a float, thought, intval() is required to get an int)
